### PR TITLE
fixed /api as begining of api url according to lykke specs

### DIFF
--- a/exchange_app/__init__.py
+++ b/exchange_app/__init__.py
@@ -31,4 +31,4 @@ mongo = PyMongo(app)
 
 # Business Logic
 from .api_1_0 import api as api_blueprint
-app.register_blueprint(api_blueprint, url_prefix='/v1.0')
+app.register_blueprint(api_blueprint, url_prefix='/api')


### PR DESCRIPTION
According to Lykke specs, the API endpoints should be like `/api/rest/of/endpoint`, we have API version.