### PR TITLE
added travis build badge, develop branch, fixes #101

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+[![Build Status](https://travis-ci.com/exchangeproject/exchange.svg?branch=develop)](https://travis-ci.com/exchangeproject/exchange)
 # Lykke Blockchain integration for Skycoin
 
 ### Requirements


### PR DESCRIPTION
The Travis-CI build status badge has been added. I've used the `develop` branch for the build statuses.