### PR TITLE
refs #120 - Tests for /api/isalive

### DIFF
--- a/exchange_app/api_1_0/isalive.py
+++ b/exchange_app/api_1_0/isalive.py
@@ -4,7 +4,6 @@ from .blockchain import get_version
 from .. import app
 from ..common import build_error
 
-
 @api.route('/isalive', methods=['GET'])
 def isalive():
     """
@@ -20,10 +19,11 @@ def isalive():
         )
 
     result = {
-        "name": "Skycoin",
-        "version": version,  # TODO: Return skycoin version or this API version?
+        "name": app.config['SKYCOIN_FIBER_NAME'],
+        "version": version,
         "env": app.config["ENVIRONMENT"],
-        "isDebug": app.config["DEBUG"]
+        "isDebug": app.config["DEBUG"],
+        "contractVersion": app.config['LYKKE_API_VERSION']
     }
 
     return jsonify(result)

--- a/exchange_app/settings.py
+++ b/exchange_app/settings.py
@@ -24,7 +24,7 @@ class Config(object):
     #: Redis
     REDIS_HOST = '127.0.0.1'
     REDIS_PORT = 6379
-    #: SKYCOIN
+    #: Skycoin
     SECRET_KEY = '1!qaz2@wsx3#edc$4rfv'
     WTF_CSRF_SECRET_KEY = '1!qaz2@wsx3#edc$4rfv'
     SKYCOIN_NODE_URL = 'http://localhost:6420/'
@@ -32,6 +32,8 @@ class Config(object):
     SKYCOIN_WALLET_SHARED = False
     SKYCOIN_FIBER_ASSET = "SKY"
     SKYCOIN_FIBER_NAME = "Skycoin"
+    #: Lykke
+    LYKKE_API_VERSION = '1.3.0'
 
 
 class ProductionConfig(Config):

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -51,7 +51,7 @@ class ApiTestCase(BaseApiTestCase):
         self.assertIn("isDebug", json_response)
         self.assertIn("contractVersion", json_response)
         self.assertEqual(json_response["name"], app_config.SKYCOIN_FIBER_NAME)
-        self.assertEqual(json_response["version"], '0.24.0')
+        self.assertEqual(json_response["version"], '0.24.1')
         self.assertEqual(json_response["env"], 'Dev')
         self.assertEqual(json_response["isDebug"], True)
         self.assertEqual(json_response["contractVersion"], app_config.LYKKE_API_VERSION)

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -27,6 +27,7 @@ URL_ADDRESS_EXPLORER = '/v1/api/addresses/{address}/explorer-url'
 URL_ADDRESS_OBSERVE  = '/v1/api/balances/{address}/observation'
 URL_BALANCES_FIRST   = '/v1/api/balances?take={limit}'
 URL_BALANCES_PAGE    = '/v1/api/balances?take={limit}&continuation={offset}'
+URL_BALANCES_PAGE    = '/v1/api/isalive'
 
 ADDRESS_VALID = r'2GgFvqoyk9RjwVzj8tqfcXVXB4orBwoc9qv'
 ADDRESS_INVALID = r'12345678'
@@ -40,6 +41,21 @@ class BaseApiTestCase(unittest.TestCase):
 
 
 class ApiTestCase(BaseApiTestCase):
+    def test_isalive(self):
+        response = self.app.get(URL_ISALIVE)
+        self.assertEqual(response.status_code, 200)
+        json_response = json.loads(response.get_data(as_text=True))
+        self.assertIn("name", json_response)
+        self.assertIn("version", json_response)
+        self.assertIn("env", json_response)
+        self.assertIn("isDebug", json_response)
+        self.assertIn("contractVersion", json_response)
+        self.assertEqual(json_response["name"], app_config.SKYCOIN_FIBER_NAME)
+        self.assertEqual(json_response["version"], '0.24.0')
+        self.assertEqual(json_response["env"], 'Dev')
+        self.assertEqual(json_response["isDebug"], True)
+        self.assertEqual(json_response["contractVersion"], app_config.LYKKE_API_VERSION)
+
     def test_address_valid(self):
         address = ADDRESS_VALID
         response = self.app.get(URL_ADDRESS_VALIDITY.format(address=address))


### PR DESCRIPTION
Refs #120 

Changes:

- `/api/isalive` returns values defined in Flask settings
- Latest Skycoin node version is `0.24.1`